### PR TITLE
Rename & reorg

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
+      {{ .Binary }}_
       {{ .ProjectName }}_
       {{- .Version }}_
       {{- title .Os }}_

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
       - linux
       - windows
       - darwin
+    binary: overmind
 
 archives:
   - format: tar.gz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ovm-cli
+# Overmind CLI
 
 CLI to interact with the overmind API
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,31 @@
 # Overmind CLI
 
-CLI to interact with the overmind API
+CLI to interact with the Overmind API
 
 ```
 Usage:
-  ovm-cli [command]
+  overmind [command]
 
-Available Commands:
-  completion             Generate the autocompletion script for the specified shell
-  create-bookmark        Creates a bookmark from JSON.
-  create-invite          Create a new invite
-  end-change             Finishes the specified change. Call this just after you finished the change. This will store a snapshot of the current system state for later reference.
-  get-affected-bookmarks Calculates the bookmarks that would be overlapping with a snapshot.
-  get-bookmark           Displays the contents of a bookmark.
-  get-change             Displays the contents of a change.
-  get-snapshot           Displays the contents of a snapshot.
-  help                   Help about any command
-  list-changes           Displays the contents of a change.
-  list-invites           List all invites
-  manual-change          Creates a new Change from a given query
-  request                Runs a request against the overmind API
-  revoke-invites         Revoke an existing invite
-  start-change           Starts the specified change. Call this just before you're about to start the change. This will store a snapshot of the current system state for later reference.
-  submit-plan            Creates a new Change from a given terraform plan file
+Infrastructure as Code:
+  terraform   Run Terrafrom with Overmind's change tracking - COMING SOON
+
+Overmind API:
+  bookmarks   Interact with the bookarks that were created in the Explore view
+  changes     Create, update and delete changes in Overmind
+  invites     Manage invites for your team to Overmind
+  request     Runs a request against the overmind API
+  snapshots   Create, view and delete snapshots if your infrastructure
+
+Additional Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
 
 Flags:
-      --api-key string             The API key to use for authentication, also read from OVM_API_KEY environment variable
-      --api-key-url string         The overmind API Keys endpoint (defaults to --url)
-      --auth0-client-id string     OAuth Client ID to use when connecting with auth (default "j3LylZtIosVPZtouKI8WuVHmE6Lluva1")
-      --auth0-domain string        Auth0 domain to connect to (default "om-prod.eu.auth0.com")
-      --gateway-url string         The overmind Gateway endpoint (defaults to /api/gateway on --url)
-  -h, --help                       help for ovm-cli
-      --honeycomb-api-key string   If specified, configures opentelemetry libraries to submit traces to honeycomb. This requires --otel to be set.
-      --json-log                   Set to true to emit logs as json for easier parsing.
-      --log string                 Set the log level. Valid values: panic, fatal, error, warn, info, debug, trace (default "info")
-      --otel                       If specified, configures opentelemetry and - optionally, see --sentry-dsn - sentry using their default environment configs.
-      --run-mode string            Set the run mode for this service, 'release', 'debug' or 'test'. Defaults to 'release'. (default "release")
-      --sentry-dsn string          If specified, configures sentry libraries to capture errors. This requires --otel to be set.
-      --stdout-trace-dump          Dump all otel traces to stdout for debugging. This requires --otel to be set.
-      --url string                 The overmind API endpoint (default "https://api.prod.overmind.tech")
-  -v, --version                    version for ovm-cli
+  -h, --help         help for overmind
+      --log string   Set the log level. Valid values: panic, fatal, error, warn, info, debug, trace (default "info")
+  -v, --version      version for overmind
 
-Use "ovm-cli [command] --help" for more information about a command.
+Use "overmind [command] --help" for more information about a command.
 ```
 
 ## Examples
@@ -50,7 +34,7 @@ Upload a terraform plan to overmind for Blast Radius Analysis:
 
 ```
 terraform show -json ./tfplan > ./tfplan.json
-ovm-cli submit-plan --title "example change" ./tfplan1.json ./tfplan2.json ./tfplan3.json
+overmind changes submit-plan --title "example change" ./tfplan1.json ./tfplan2.json ./tfplan3.json
 ```
 
 ## Terraform ➡ Overmind Mapping

--- a/cmd/auth_client.go
+++ b/cmd/auth_client.go
@@ -33,12 +33,8 @@ func UnauthenticatedApiKeyClient(ctx context.Context) sdpconnect.ApiKeyServiceCl
 // embedded in the context and otel instrumentation
 func AuthenticatedBookmarkClient(ctx context.Context) sdpconnect.BookmarksServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	url := viper.GetString("bookmark-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("bookmark-url", url)
-	}
-	log.WithContext(ctx).WithField("bookmark-url", url).Debug("Connecting to overmind bookmark API")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind bookmark API")
 	return sdpconnect.NewBookmarksServiceClient(httpClient, url)
 }
 
@@ -46,12 +42,8 @@ func AuthenticatedBookmarkClient(ctx context.Context) sdpconnect.BookmarksServic
 // embedded in the context and otel instrumentation
 func AuthenticatedChangesClient(ctx context.Context) sdpconnect.ChangesServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	url := viper.GetString("changes-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("changes-url", url)
-	}
-	log.WithContext(ctx).WithField("changes-url", url).Debug("Connecting to overmind changes API")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind changes API")
 	return sdpconnect.NewChangesServiceClient(httpClient, url)
 }
 
@@ -59,12 +51,8 @@ func AuthenticatedChangesClient(ctx context.Context) sdpconnect.ChangesServiceCl
 // embedded in the context and otel instrumentation
 func AuthenticatedManagementClient(ctx context.Context) sdpconnect.ManagementServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	url := viper.GetString("management-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("management-url", url)
-	}
-	log.WithContext(ctx).WithField("management-url", url).Debug("Connecting to overmind management API")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind management API")
 	return sdpconnect.NewManagementServiceClient(httpClient, url)
 }
 
@@ -72,12 +60,8 @@ func AuthenticatedManagementClient(ctx context.Context) sdpconnect.ManagementSer
 // embedded in the context and otel instrumentation
 func AuthenticatedSnapshotsClient(ctx context.Context) sdpconnect.SnapshotsServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	url := viper.GetString("snapshot-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("snapshot-url", url)
-	}
-	log.WithContext(ctx).WithField("snapshot-url", url).Debug("Connecting to overmind snapshot API")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind snapshot API")
 	return sdpconnect.NewSnapshotsServiceClient(httpClient, url)
 }
 
@@ -85,12 +69,8 @@ func AuthenticatedSnapshotsClient(ctx context.Context) sdpconnect.SnapshotsServi
 // embedded in the context and otel instrumentation
 func AuthenticatedInviteClient(ctx context.Context) sdpconnect.InviteServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	url := viper.GetString("invite-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("invite-url", url)
-	}
-	log.WithContext(ctx).WithField("invite-url", url).Debug("Connecting to overmind invite API")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind invite API")
 	return sdpconnect.NewInviteServiceClient(httpClient, url)
 }
 

--- a/cmd/auth_client.go
+++ b/cmd/auth_client.go
@@ -16,24 +16,16 @@ import (
 // embedded in the context and otel instrumentation
 func AuthenticatedApiKeyClient(ctx context.Context) sdpconnect.ApiKeyServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	url := viper.GetString("api-key-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("api-key-url", url)
-	}
-	log.WithContext(ctx).WithField("api-key-url", url).Debug("Connecting to overmind apikeys API (pre-authenticated)")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind apikeys API (pre-authenticated)")
 	return sdpconnect.NewApiKeyServiceClient(httpClient, url)
 }
 
 // UnauthenticatedApiKeyClient Returns an apikey client with otel instrumentation
 // but no authentication. Can only be used for ExchangeKeyForToken
 func UnauthenticatedApiKeyClient(ctx context.Context) sdpconnect.ApiKeyServiceClient {
-	url := viper.GetString("api-key-url")
-	if url == "" {
-		url = viper.GetString("url")
-		viper.Set("api-key-url", url)
-	}
-	log.WithContext(ctx).WithField("api-key-url", url).Debug("Connecting to overmind apikeys API")
+	url := viper.GetString("url")
+	log.WithContext(ctx).WithField("url", url).Debug("Connecting to overmind apikeys API")
 	return sdpconnect.NewApiKeyServiceClient(otelhttp.DefaultClient, url)
 }
 

--- a/cmd/bookmarks.go
+++ b/cmd/bookmarks.go
@@ -22,6 +22,8 @@ executed as a single block.`,
 func init() {
 	rootCmd.AddCommand(bookmarksCmd)
 
+	addAPIFlags(bookmarksCmd)
+
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/bookmarks.go
+++ b/cmd/bookmarks.go
@@ -15,7 +15,7 @@ var bookmarksCmd = &cobra.Command{
 	Long: `A bookmark in Overmind is a set of queries that are stored together and can be
 executed as a single block.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/bookmarks.go
+++ b/cmd/bookmarks.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// bookmarksCmd represents the bookmarks command
+var bookmarksCmd = &cobra.Command{
+	Use:     "bookmarks",
+	GroupID: "api",
+	Short:   "Interact with the bookarks that were created in the Explore view",
+	Long: `A bookmark in Overmind is a set of queries that are stored together and can be
+executed as a single block.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(bookmarksCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// bookmarksCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// bookmarksCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/bookmarks_create_bookmark.go
+++ b/cmd/bookmarks_create_bookmark.go
@@ -108,7 +108,7 @@ func CreateBookmark(ctx context.Context, ready chan bool) int {
 	})
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithFields(log.Fields{
-			"bookmark-url": viper.GetString("bookmark-url"),
+			"url": viper.GetString("url"),
 		}).Error("failed to get bookmark")
 		return 1
 	}
@@ -142,9 +142,5 @@ func CreateBookmark(ctx context.Context, ready chan bool) int {
 func init() {
 	bookmarksCmd.AddCommand(createBookmarkCmd)
 
-	createBookmarkCmd.PersistentFlags().String("bookmark-url", "", "The bookmark service API endpoint (defaults to --url)")
-
 	createBookmarkCmd.PersistentFlags().String("file", "", "JSON formatted file to read bookmark. (defaults to stdin)")
-
-	createBookmarkCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }

--- a/cmd/bookmarks_create_bookmark.go
+++ b/cmd/bookmarks_create_bookmark.go
@@ -12,7 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -140,7 +140,7 @@ func CreateBookmark(ctx context.Context, ready chan bool) int {
 }
 
 func init() {
-	rootCmd.AddCommand(createBookmarkCmd)
+	bookmarksCmd.AddCommand(createBookmarkCmd)
 
 	createBookmarkCmd.PersistentFlags().String("bookmark-url", "", "The bookmark service API endpoint (defaults to --url)")
 

--- a/cmd/bookmarks_get_affected_bookmarks.go
+++ b/cmd/bookmarks_get_affected_bookmarks.go
@@ -102,7 +102,7 @@ func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
 	})
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithFields(log.Fields{
-			"bookmark-url": viper.GetString("bookmark-url"),
+			"url": viper.GetString("url"),
 		}).Error("failed to get affected bookmarks")
 		return 1
 	}
@@ -118,11 +118,6 @@ func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
 func init() {
 	bookmarksCmd.AddCommand(getAffectedBookmarksCmd)
 
-	getAffectedBookmarksCmd.PersistentFlags().String("bookmark-url", "", "The bookmark service API endpoint (defaults to --url)")
-	getAffectedBookmarksCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
-
 	getAffectedBookmarksCmd.PersistentFlags().String("snapshot-uuid", "", "The UUID of the snapshot that should be checked.")
 	getAffectedBookmarksCmd.PersistentFlags().String("bookmark-uuids", "", "A comma separated list of UUIDs of the potentially affected bookmarks.")
-
-	getAffectedBookmarksCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }

--- a/cmd/bookmarks_get_affected_bookmarks.go
+++ b/cmd/bookmarks_get_affected_bookmarks.go
@@ -10,7 +10,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -116,7 +116,7 @@ func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
 }
 
 func init() {
-	rootCmd.AddCommand(getAffectedBookmarksCmd)
+	bookmarksCmd.AddCommand(getAffectedBookmarksCmd)
 
 	getAffectedBookmarksCmd.PersistentFlags().String("bookmark-url", "", "The bookmark service API endpoint (defaults to --url)")
 	getAffectedBookmarksCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")

--- a/cmd/bookmarks_get_bookmark.go
+++ b/cmd/bookmarks_get_bookmark.go
@@ -91,7 +91,7 @@ func GetBookmark(ctx context.Context, ready chan bool) int {
 	})
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithFields(log.Fields{
-			"bookmark-url": viper.GetString("bookmark-url"),
+			"url": viper.GetString("url"),
 		}).Error("failed to get bookmark")
 		return 1
 	}
@@ -115,9 +115,5 @@ func GetBookmark(ctx context.Context, ready chan bool) int {
 func init() {
 	bookmarksCmd.AddCommand(getBookmarkCmd)
 
-	getBookmarkCmd.PersistentFlags().String("bookmark-url", "", "The bookmark service API endpoint (defaults to --url)")
-
 	getBookmarkCmd.PersistentFlags().String("uuid", "", "The UUID of the bookmark that should be displayed.")
-
-	getBookmarkCmd.PersistentFlags().String("timeout", "1m", "How long to wait for responses")
 }

--- a/cmd/bookmarks_get_bookmark.go
+++ b/cmd/bookmarks_get_bookmark.go
@@ -11,7 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -113,7 +113,7 @@ func GetBookmark(ctx context.Context, ready chan bool) int {
 }
 
 func init() {
-	rootCmd.AddCommand(getBookmarkCmd)
+	bookmarksCmd.AddCommand(getBookmarkCmd)
 
 	getBookmarkCmd.PersistentFlags().String("bookmark-url", "", "The bookmark service API endpoint (defaults to --url)")
 

--- a/cmd/changes.go
+++ b/cmd/changes.go
@@ -13,7 +13,7 @@ var changesCmd = &cobra.Command{
 easier to use our IaC wrappers such as 'overmind terraform plan' rather than
 using these commands directly, but they are provided for flexibility.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/changes.go
+++ b/cmd/changes.go
@@ -20,6 +20,8 @@ using these commands directly, but they are provided for flexibility.`,
 func init() {
 	rootCmd.AddCommand(changesCmd)
 
+	addAPIFlags(changesCmd)
+
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/changes.go
+++ b/cmd/changes.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// changesCmd represents the changes command
+var changesCmd = &cobra.Command{
+	Use:     "changes",
+	GroupID: "api",
+	Short:   "Create, update and delete changes in Overmind",
+	Long: `Manage changes that are being tracked using Overmind. NOTE: It is probably
+easier to use our IaC wrappers such as 'overmind terraform plan' rather than
+using these commands directly, but they are provided for flexibility.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(changesCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// changesCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// changesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/changes_end_change.go
+++ b/cmd/changes_end_change.go
@@ -116,9 +116,5 @@ func EndChange(ctx context.Context, ready chan bool) int {
 func init() {
 	changesCmd.AddCommand(endChangeCmd)
 
-	withChangeUuidFlags(endChangeCmd)
-
-	endChangeCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
-
-	endChangeCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
+	addChangeUuidFlags(endChangeCmd)
 }

--- a/cmd/changes_end_change.go
+++ b/cmd/changes_end_change.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -18,15 +18,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// startChangeCmd represents the start-change command
-var startChangeCmd = &cobra.Command{
-	Use:   "start-change --uuid ID",
-	Short: "Starts the specified change. Call this just before you're about to start the change. This will store a snapshot of the current system state for later reference.",
+// endChangeCmd represents the end-change command
+var endChangeCmd = &cobra.Command{
+	Use:   "end-change --uuid ID",
+	Short: "Finishes the specified change. Call this just after you finished the change. This will store a snapshot of the current system state for later reference.",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// Bind these to viper
 		err := viper.BindPFlags(cmd.Flags())
 		if err != nil {
-			log.WithError(err).Fatal("could not bind `start-change` flags")
+			log.WithError(err).Fatal("could not bind `end-change` flags")
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -45,20 +45,20 @@ var startChangeCmd = &cobra.Command{
 			}
 		}()
 
-		exitcode := StartChange(ctx, nil)
+		exitcode := EndChange(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
 }
 
-func StartChange(ctx context.Context, ready chan bool) int {
+func EndChange(ctx context.Context, ready chan bool) int {
 	timeout, err := time.ParseDuration(viper.GetString("timeout"))
 	if err != nil {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
 		return 1
 	}
 
-	ctx, span := tracing.Tracer().Start(ctx, "CLI StartChange", trace.WithAttributes(
+	ctx, span := tracing.Tracer().Start(ctx, "CLI EndChange", trace.WithAttributes(
 		attribute.String("ovm.config", fmt.Sprintf("%v", viper.AllSettings())),
 	))
 	defer span.End()
@@ -76,7 +76,7 @@ func StartChange(ctx context.Context, ready chan bool) int {
 	defer cancel()
 
 	lf := log.Fields{}
-	changeUuid, err := getChangeUuid(ctx, sdp.ChangeStatus_CHANGE_STATUS_DEFINING, true)
+	changeUuid, err := getChangeUuid(ctx, sdp.ChangeStatus_CHANGE_STATUS_HAPPENING, true)
 	if err != nil {
 		log.WithError(err).WithFields(lf).Error("failed to identify change")
 		return 1
@@ -86,13 +86,13 @@ func StartChange(ctx context.Context, ready chan bool) int {
 
 	// snapClient := AuthenticatedSnapshotsClient(ctx)
 	client := AuthenticatedChangesClient(ctx)
-	stream, err := client.StartChange(ctx, &connect.Request[sdp.StartChangeRequest]{
-		Msg: &sdp.StartChangeRequest{
+	stream, err := client.EndChange(ctx, &connect.Request[sdp.EndChangeRequest]{
+		Msg: &sdp.EndChangeRequest{
 			ChangeUUID: changeUuid[:],
 		},
 	})
 	if err != nil {
-		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to start change")
+		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to end change")
 		return 1
 	}
 	log.WithContext(ctx).WithFields(lf).Info("processing")
@@ -105,20 +105,20 @@ func StartChange(ctx context.Context, ready chan bool) int {
 		}).Info("progress")
 	}
 	if stream.Err() != nil {
-		log.WithContext(ctx).WithFields(lf).WithError(stream.Err()).Error("failed to process start change")
+		log.WithContext(ctx).WithFields(lf).WithError(stream.Err()).Error("failed to process end change")
 		return 1
 	}
 
-	log.WithContext(ctx).WithFields(lf).Info("started change")
+	log.WithContext(ctx).WithFields(lf).Info("finished change")
 	return 0
 }
 
 func init() {
-	rootCmd.AddCommand(startChangeCmd)
+	changesCmd.AddCommand(endChangeCmd)
 
-	withChangeUuidFlags(startChangeCmd)
+	withChangeUuidFlags(endChangeCmd)
 
-	startChangeCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
+	endChangeCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
 
-	startChangeCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
+	endChangeCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }

--- a/cmd/changes_get_change.go
+++ b/cmd/changes_get_change.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	diffspan "github.com/hexops/gotextdiff/span"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -245,7 +245,7 @@ fetch:
 			BlastItems:      int(changeRes.Msg.GetChange().GetMetadata().GetNumAffectedItems()),
 			BlastEdges:      int(changeRes.Msg.GetChange().GetMetadata().GetNumAffectedEdges()),
 			Risks:           []TemplateRisk{},
-			AssetPath:       fmt.Sprintf("https://raw.githubusercontent.com/overmindtech/ovm-cli/%v/assets", assetVersion),
+			AssetPath:       fmt.Sprintf("https://raw.githubusercontent.com/overmindtech/cli/%v/assets", assetVersion),
 		}
 
 		for _, item := range changeRes.Msg.GetChange().GetProperties().GetPlannedChanges() {
@@ -324,7 +324,7 @@ fetch:
 }
 
 func init() {
-	rootCmd.AddCommand(getChangeCmd)
+	changesCmd.AddCommand(getChangeCmd)
 
 	withChangeUuidFlags(getChangeCmd)
 	getChangeCmd.PersistentFlags().String("status", "", "The expected status of the change. Use this with --ticket-link. Allowed values: CHANGE_STATUS_UNSPECIFIED, CHANGE_STATUS_DEFINING, CHANGE_STATUS_HAPPENING, CHANGE_STATUS_PROCESSING, CHANGE_STATUS_DONE")

--- a/cmd/changes_get_change.go
+++ b/cmd/changes_get_change.go
@@ -326,11 +326,9 @@ fetch:
 func init() {
 	changesCmd.AddCommand(getChangeCmd)
 
-	withChangeUuidFlags(getChangeCmd)
+	addChangeUuidFlags(getChangeCmd)
 	getChangeCmd.PersistentFlags().String("status", "", "The expected status of the change. Use this with --ticket-link. Allowed values: CHANGE_STATUS_UNSPECIFIED, CHANGE_STATUS_DEFINING, CHANGE_STATUS_HAPPENING, CHANGE_STATUS_PROCESSING, CHANGE_STATUS_DONE")
 
 	getChangeCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
 	getChangeCmd.PersistentFlags().String("format", "json", "How to render the change. Possible values: json, markdown")
-
-	getChangeCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }

--- a/cmd/changes_list_changes.go
+++ b/cmd/changes_list_changes.go
@@ -289,10 +289,7 @@ func printJson(ctx context.Context, b []byte, prefix, id string) error {
 func init() {
 	changesCmd.AddCommand(listChangesCmd)
 
-	listChangesCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
 	listChangesCmd.PersistentFlags().String("format", "files", "How to render the change. Possible values: files, json")
 	listChangesCmd.PersistentFlags().String("dir", "./output", "A directory name to use for rendering changes when using the 'files' format")
 	listChangesCmd.PersistentFlags().Bool("fetch-data", false, "also fetch the blast radius and system state snapshots for each change")
-
-	listChangesCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }

--- a/cmd/changes_list_changes.go
+++ b/cmd/changes_list_changes.go
@@ -12,7 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -287,7 +287,7 @@ func printJson(ctx context.Context, b []byte, prefix, id string) error {
 }
 
 func init() {
-	rootCmd.AddCommand(listChangesCmd)
+	changesCmd.AddCommand(listChangesCmd)
 
 	listChangesCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
 	listChangesCmd.PersistentFlags().String("format", "files", "How to render the change. Possible values: files, json")

--- a/cmd/changes_manual_change.go
+++ b/cmd/changes_manual_change.go
@@ -11,7 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	"github.com/overmindtech/sdp-go/sdpws"
 	log "github.com/sirupsen/logrus"
@@ -225,7 +225,7 @@ func ManualChange(ctx context.Context, ready chan bool) int {
 }
 
 func init() {
-	rootCmd.AddCommand(manualChangeCmd)
+	changesCmd.AddCommand(manualChangeCmd)
 
 	manualChangeCmd.PersistentFlags().String("changes-url", "", "The changes service API endpoint (defaults to --url)")
 	manualChangeCmd.PersistentFlags().String("management-url", "", "The management service API endpoint (defaults to --url)")

--- a/cmd/changes_manual_change.go
+++ b/cmd/changes_manual_change.go
@@ -11,6 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
+	"github.com/overmindtech/cli/internal"
 	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	"github.com/overmindtech/sdp-go/sdpws"
@@ -67,17 +68,11 @@ func ManualChange(ctx context.Context, ready chan bool) int {
 	))
 	defer span.End()
 
-	gatewayUrl := viper.GetString("gateway-url")
-	if gatewayUrl == "" {
-		gatewayUrl = fmt.Sprintf("%v/api/gateway", viper.GetString("url"))
-		viper.Set("gateway-url", gatewayUrl)
-	}
-
 	lf := log.Fields{}
 
 	ctx, err = ensureToken(ctx, []string{"changes:write"})
 	if err != nil {
-		log.WithContext(ctx).WithFields(lf).WithField("api-key-url", viper.GetString("api-key-url")).WithError(err).Error("failed to authenticate")
+		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to authenticate")
 		return 1
 	}
 
@@ -130,7 +125,7 @@ func ManualChange(ctx context.Context, ready chan bool) int {
 		return 1
 	}
 
-	ws, err := sdpws.DialBatch(ctx, gatewayUrl, otelhttp.DefaultClient, nil)
+	ws, err := sdpws.DialBatch(ctx, internal.GatewayURL(viper.GetString("url")), otelhttp.DefaultClient, nil)
 	if err != nil {
 		log.WithContext(ctx).WithFields(lf).WithError(err).Error("Failed to connect to gateway")
 		return 1

--- a/cmd/changes_manual_change.go
+++ b/cmd/changes_manual_change.go
@@ -222,8 +222,6 @@ func ManualChange(ctx context.Context, ready chan bool) int {
 func init() {
 	changesCmd.AddCommand(manualChangeCmd)
 
-	manualChangeCmd.PersistentFlags().String("changes-url", "", "The changes service API endpoint (defaults to --url)")
-	manualChangeCmd.PersistentFlags().String("management-url", "", "The management service API endpoint (defaults to --url)")
 	manualChangeCmd.PersistentFlags().String("frontend", "https://app.overmind.tech", "The frontend base URL")
 
 	manualChangeCmd.PersistentFlags().String("title", "", "Short title for this change.")
@@ -236,6 +234,4 @@ func init() {
 	manualChangeCmd.PersistentFlags().String("query-scope", "*", "The scope to query")
 	manualChangeCmd.PersistentFlags().String("query-type", "*", "The type to query")
 	manualChangeCmd.PersistentFlags().String("query", "", "The actual query to send")
-
-	manualChangeCmd.PersistentFlags().String("timeout", "3m", "How long to wait for responses")
 }

--- a/cmd/changes_submit_plan.go
+++ b/cmd/changes_submit_plan.go
@@ -726,8 +726,6 @@ func SubmitPlan(ctx context.Context, files []string, ready chan bool) int {
 func init() {
 	changesCmd.AddCommand(submitPlanCmd)
 
-	submitPlanCmd.PersistentFlags().String("changes-url", "", "The changes service API endpoint (defaults to --url)")
-	submitPlanCmd.PersistentFlags().String("management-url", "", "The management service API endpoint (defaults to --url)")
 	submitPlanCmd.PersistentFlags().String("frontend", "https://app.overmind.tech", "The frontend base URL")
 
 	submitPlanCmd.PersistentFlags().String("title", "", "Short title for this change. If this is not specified, overmind will try to come up with one for you.")
@@ -738,6 +736,4 @@ func init() {
 
 	submitPlanCmd.PersistentFlags().String("terraform-plan-output", "", "Filename of cached terraform plan output for this change.")
 	submitPlanCmd.PersistentFlags().String("code-changes-diff", "", "Fileame of the code diff of this change.")
-
-	submitPlanCmd.PersistentFlags().String("timeout", "3m", "How long to wait for responses")
 }

--- a/cmd/changes_submit_plan.go
+++ b/cmd/changes_submit_plan.go
@@ -17,8 +17,8 @@ import (
 	"connectrpc.com/connect"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/cmd/datamaps"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/cmd/datamaps"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -730,13 +730,13 @@ func SubmitPlan(ctx context.Context, files []string, ready chan bool) int {
 }
 
 func init() {
-	rootCmd.AddCommand(submitPlanCmd)
+	changesCmd.AddCommand(submitPlanCmd)
 
 	submitPlanCmd.PersistentFlags().String("changes-url", "", "The changes service API endpoint (defaults to --url)")
 	submitPlanCmd.PersistentFlags().String("management-url", "", "The management service API endpoint (defaults to --url)")
 	submitPlanCmd.PersistentFlags().String("frontend", "https://app.overmind.tech", "The frontend base URL")
 
-	submitPlanCmd.PersistentFlags().String("title", "", "Short title for this change. If this is not specified, ovm-cli will try to come up with one for you.")
+	submitPlanCmd.PersistentFlags().String("title", "", "Short title for this change. If this is not specified, overmind will try to come up with one for you.")
 	submitPlanCmd.PersistentFlags().String("description", "", "Quick description of the change.")
 	submitPlanCmd.PersistentFlags().String("ticket-link", "*", "Link to the ticket for this change.")
 	submitPlanCmd.PersistentFlags().String("owner", "", "The owner of this change.")

--- a/cmd/changes_submit_plan.go
+++ b/cmd/changes_submit_plan.go
@@ -564,17 +564,11 @@ func SubmitPlan(ctx context.Context, files []string, ready chan bool) int {
 	))
 	defer span.End()
 
-	gatewayUrl := viper.GetString("gateway-url")
-	if gatewayUrl == "" {
-		gatewayUrl = fmt.Sprintf("%v/api/gateway", viper.GetString("url"))
-		viper.Set("gateway-url", gatewayUrl)
-	}
-
 	lf := log.Fields{}
 
 	ctx, err = ensureToken(ctx, []string{"changes:write"})
 	if err != nil {
-		log.WithContext(ctx).WithFields(lf).WithField("api-key-url", viper.GetString("api-key-url")).WithError(err).Error("failed to authenticate")
+		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to authenticate")
 		return 1
 	}
 

--- a/cmd/chnages_start_change.go
+++ b/cmd/chnages_start_change.go
@@ -116,9 +116,5 @@ func StartChange(ctx context.Context, ready chan bool) int {
 func init() {
 	changesCmd.AddCommand(startChangeCmd)
 
-	withChangeUuidFlags(startChangeCmd)
-
-	startChangeCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
-
-	startChangeCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
+	addChangeUuidFlags(startChangeCmd)
 }

--- a/cmd/invites.go
+++ b/cmd/invites.go
@@ -18,6 +18,7 @@ var invitesCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(invitesCmd)
 
+	addAPIFlags(invitesCmd)
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/invites.go
+++ b/cmd/invites.go
@@ -11,7 +11,7 @@ var invitesCmd = &cobra.Command{
 	Short:   "Manage invites for your team to Overmind",
 	Long:    `Create and revoke Overmind invitations`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/invites.go
+++ b/cmd/invites.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// invitesCmd represents the invites command
+var invitesCmd = &cobra.Command{
+	Use:     "invites",
+	GroupID: "api",
+	Short:   "Manage invites for your team to Overmind",
+	Long:    `Create and revoke Overmind invitations`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(invitesCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// invitesCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// invitesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/invites_crud.go
+++ b/cmd/invites_crud.go
@@ -9,7 +9,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -237,16 +237,16 @@ func InvitesList(ctx context.Context) int {
 
 func init() {
 	// list sub-command
-	rootCmd.AddCommand(listCmd)
+	invitesCmd.AddCommand(listCmd)
 	listCmd.PersistentFlags().String("invite-url", "", "A custom URL for the invites API (optional)")
 
 	// create sub-command
-	rootCmd.AddCommand(createCmd)
+	invitesCmd.AddCommand(createCmd)
 	createCmd.PersistentFlags().String("invite-url", "", "A custom URL for the invites API (optional)")
 	createCmd.PersistentFlags().StringSlice("emails", []string{}, "A list of emails to invite")
 
 	// revoke sub-command
-	rootCmd.AddCommand(revokeCmd)
+	invitesCmd.AddCommand(revokeCmd)
 	revokeCmd.PersistentFlags().String("invite-url", "", "A custom URL for the invites API (optional)")
 	revokeCmd.PersistentFlags().String("email", "", "The email address to revoke")
 }

--- a/cmd/invites_crud.go
+++ b/cmd/invites_crud.go
@@ -238,15 +238,12 @@ func InvitesList(ctx context.Context) int {
 func init() {
 	// list sub-command
 	invitesCmd.AddCommand(listCmd)
-	listCmd.PersistentFlags().String("invite-url", "", "A custom URL for the invites API (optional)")
 
 	// create sub-command
 	invitesCmd.AddCommand(createCmd)
-	createCmd.PersistentFlags().String("invite-url", "", "A custom URL for the invites API (optional)")
 	createCmd.PersistentFlags().StringSlice("emails", []string{}, "A list of emails to invite")
 
 	// revoke sub-command
 	invitesCmd.AddCommand(revokeCmd)
-	revokeCmd.PersistentFlags().String("invite-url", "", "A custom URL for the invites API (optional)")
 	revokeCmd.PersistentFlags().String("email", "", "The email address to revoke")
 }

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/overmindtech/cli/internal"
 	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	"github.com/overmindtech/sdp-go/sdpws"
@@ -141,17 +142,11 @@ func Request(ctx context.Context, ready chan bool) int {
 	))
 	defer span.End()
 
-	gatewayUrl := viper.GetString("gateway-url")
-	if gatewayUrl == "" {
-		gatewayUrl = fmt.Sprintf("%v/api/gateway", viper.GetString("url"))
-		viper.Set("gateway-url", gatewayUrl)
-	}
-
 	lf := log.Fields{}
 
 	ctx, err = ensureToken(ctx, []string{"explore:read"})
 	if err != nil {
-		log.WithContext(ctx).WithFields(lf).WithField("api-key-url", viper.GetString("api-key-url")).WithError(err).Error("failed to authenticate")
+		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to authenticate")
 		return 1
 	}
 
@@ -166,6 +161,7 @@ func Request(ctx context.Context, ready chan bool) int {
 		edges:                        []*sdp.Edge{},
 		msgLog:                       []*sdp.GatewayResponse{},
 	}
+	gatewayUrl := internal.GatewayURL(viper.GetString("url"))
 	c, err := sdpws.DialBatch(ctx, gatewayUrl,
 		NewAuthenticatedClient(ctx, otelhttp.DefaultClient),
 		handler,

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	"github.com/overmindtech/sdp-go/sdpws"
 	log "github.com/sirupsen/logrus"
@@ -24,8 +24,9 @@ import (
 
 // requestCmd represents the start command
 var requestCmd = &cobra.Command{
-	Use:   "request",
-	Short: "Runs a request against the overmind API",
+	Use:     "request",
+	GroupID: "api",
+	Short:   "Runs a request against the overmind API",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// Bind these to viper
 		err := viper.BindPFlags(cmd.Flags())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -421,8 +421,9 @@ func addChangeUuidFlags(cmd *cobra.Command) {
 }
 
 // Adds common flags to API commands e.g. timeout
-func addAPIFlags(cnd *cobra.Command) {
-	createBookmarkCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
+func addAPIFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
+	cmd.PersistentFlags().String("url", "https://api.prod.overmind.tech", "The overmind API endpoint")
 }
 
 func init() {
@@ -430,7 +431,6 @@ func init() {
 
 	// General Config
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log", "info", "Set the log level. Valid values: panic, fatal, error, warn, info, debug, trace")
-	rootCmd.PersistentFlags().String("url", "https://api.prod.overmind.tech", "The overmind API endpoint")
 
 	// Support API Keys in the environment
 	err := viper.BindEnv("api-key", "OVM_API_KEY", "API_KEY")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -34,9 +34,9 @@ var cliVersion string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "ovm-cli",
-	Short:   "A CLI to interact with the overmind API",
-	Long:    `The ovm-cli allows direct access to the overmind API`,
+	Use:     "overmind",
+	Short:   "The Overmind CLI",
+	Long:    `Calculate the blast radius of your changes, track risks, and make changes with confidence`,
 	Version: cliVersion,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// Bind these to viper
@@ -415,6 +415,14 @@ func withChangeUuidFlags(cmd *cobra.Command) {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	// TODO: I'm leaving this for now but I want to go over these and remove a
+	// bunch of them, but I want to get options before I do. The things I'm
+	// considering are:
+	//
+	// * Move some into a helper like `withChangeUuidFlags` such as log level
+	// * For things that are only used internally, move to only using env vars i.e. honeycomb, sentry, client_id
+	// * Completely remove things that aren't used such as stdout trace dump
+
 	// General Config
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log", "info", "Set the log level. Valid values: panic, fatal, error, warn, info, debug, trace")
 
@@ -441,6 +449,16 @@ func init() {
 
 	// debugging
 	rootCmd.PersistentFlags().Bool("stdout-trace-dump", false, "Dump all otel traces to stdout for debugging. This requires --otel to be set.")
+
+	// Create groups
+	rootCmd.AddGroup(&cobra.Group{
+		ID:    "iac",
+		Title: "Infrastructure as Code:",
+	})
+	rootCmd.AddGroup(&cobra.Group{
+		ID:    "api",
+		Title: "Overmind API:",
+	})
 
 	// Run this before we do anything to set up the loglevel
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -443,7 +443,10 @@ func init() {
 	// Mark this as hidden. This means that it will still be parsed of supplied,
 	// and we will still look for it in the environment, but it won't be shown
 	// in the help
-	rootCmd.PersistentFlags().MarkHidden("honeycomb-api-key")
+	err = rootCmd.PersistentFlags().MarkHidden("honeycomb-api-key")
+	if err != nil {
+		log.WithError(err).Fatal("could not mark `honeycomb-api-key` flag as hidden")
+	}
 
 	// Create groups
 	rootCmd.AddGroup(&cobra.Group{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -413,11 +413,16 @@ func parseChangeUrl(changeUrlString string) (uuid.UUID, error) {
 	return changeUuid, nil
 }
 
-func withChangeUuidFlags(cmd *cobra.Command) {
+func addChangeUuidFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("change", "", "The frontend URL of the change to get")
 	cmd.PersistentFlags().String("ticket-link", "", "Link to the ticket for this change.")
 	cmd.PersistentFlags().String("uuid", "", "The UUID of the change that should be displayed.")
 	cmd.MarkFlagsMutuallyExclusive("change", "ticket-link", "uuid")
+}
+
+// Adds common flags to API commands e.g. timeout
+func addAPIFlags(cnd *cobra.Command) {
+	createBookmarkCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }
 
 func init() {
@@ -425,8 +430,6 @@ func init() {
 
 	// General Config
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log", "info", "Set the log level. Valid values: panic, fatal, error, warn, info, debug, trace")
-
-	// api endpoint
 	rootCmd.PersistentFlags().String("url", "https://api.prod.overmind.tech", "The overmind API endpoint")
 
 	// Support API Keys in the environment
@@ -440,7 +443,7 @@ func init() {
 	// Mark this as hidden. This means that it will still be parsed of supplied,
 	// and we will still look for it in the environment, but it won't be shown
 	// in the help
-	rootCmd.Flags().MarkHidden("honeycomb-api-key")
+	rootCmd.PersistentFlags().MarkHidden("honeycomb-api-key")
 
 	// Create groups
 	rootCmd.AddGroup(&cobra.Group{

--- a/cmd/snapshots.go
+++ b/cmd/snapshots.go
@@ -13,7 +13,7 @@ var snapshotsCmd = &cobra.Command{
 however you can use these commands to interact directly with the API if
 required.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/snapshots.go
+++ b/cmd/snapshots.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// snapshotsCmd represents the snapshots command
+var snapshotsCmd = &cobra.Command{
+	Use:     "snapshots",
+	GroupID: "api",
+	Short:   "Create, view and delete snapshots if your infrastructure",
+	Long: `Overmind automatically creates snapshots are part of the change lifecycle,
+however you can use these commands to interact directly with the API if
+required.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(snapshotsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// snapshotsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// snapshotsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/snapshots.go
+++ b/cmd/snapshots.go
@@ -20,6 +20,8 @@ required.`,
 func init() {
 	rootCmd.AddCommand(snapshotsCmd)
 
+	addAPIFlags(snapshotsCmd)
+
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/snapshots_get_snapshot.go
+++ b/cmd/snapshots_get_snapshot.go
@@ -11,7 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/ovm-cli/tracing"
+	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -128,7 +128,7 @@ func GetSnapshot(ctx context.Context, ready chan bool) int {
 }
 
 func init() {
-	rootCmd.AddCommand(getSnapshotCmd)
+	snapshotsCmd.AddCommand(getSnapshotCmd)
 
 	getSnapshotCmd.PersistentFlags().String("snapshot-url", "", "The snapshot service API endpoint (defaults to --url)")
 	getSnapshotCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")

--- a/cmd/snapshots_get_snapshot.go
+++ b/cmd/snapshots_get_snapshot.go
@@ -91,7 +91,7 @@ func GetSnapshot(ctx context.Context, ready chan bool) int {
 	})
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithFields(log.Fields{
-			"snapshot-url": viper.GetString("snapshot-url"),
+			"url": viper.GetString("url"),
 		}).Error("failed to get snapshot")
 		return 1
 	}
@@ -130,10 +130,5 @@ func GetSnapshot(ctx context.Context, ready chan bool) int {
 func init() {
 	snapshotsCmd.AddCommand(getSnapshotCmd)
 
-	getSnapshotCmd.PersistentFlags().String("snapshot-url", "", "The snapshot service API endpoint (defaults to --url)")
-	getSnapshotCmd.PersistentFlags().String("frontend", "https://app.overmind.tech/", "The frontend base URL")
-
 	getSnapshotCmd.PersistentFlags().String("uuid", "", "The UUID of the snapshot that should be displayed.")
-
-	getSnapshotCmd.PersistentFlags().String("timeout", "5m", "How long to wait for responses")
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -11,7 +11,7 @@ var terraformCmd = &cobra.Command{
 	Short:   "Run Terrafrom with Overmind's change tracking - COMING SOON",
 	Long:    `COMING SOON`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -18,9 +18,6 @@ var terraformCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(terraformCmd)
 
-	// Hide this flag from the Terraform help as we don't want it to be messy
-	rootCmd.PersistentFlags().MarkHidden("url")
-
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// terraformCmd represents the terraform command
+var terraformCmd = &cobra.Command{
+	Use:     "terraform",
+	GroupID: "iac",
+	Short:   "Run Terrafrom with Overmind's change tracking - COMING SOON",
+	Long:    `COMING SOON`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(terraformCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// terraformCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// terraformCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -18,6 +18,9 @@ var terraformCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(terraformCmd)
 
+	// Hide this flag from the Terraform help as we don't want it to be messy
+	rootCmd.PersistentFlags().MarkHidden("url")
+
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/overmindtech/ovm-cli
+module github.com/overmindtech/cli
 
 go 1.22.0
 

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -1,0 +1,10 @@
+package internal
+
+import "fmt"
+
+// GatewayURL returns the URL for the gateway for a given pase URL. For example
+// if the base URL is https://api.prod.overmind.tech, the gateway URL will be
+// https://api.prod.overmind.tech/api/gateway
+func GatewayURL(base string) string {
+	return fmt.Sprintf("%v/api/gateway", base)
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/overmindtech/ovm-cli/cmd"
+import "github.com/overmindtech/cli/cmd"
 
 func main() {
 	cmd.Execute()

--- a/tracing/main.go
+++ b/tracing/main.go
@@ -28,7 +28,7 @@ import (
 //go:embed commit.txt
 var instrumentationVersion string
 
-const instrumentationName = "github.com/overmindtech/ovm-cli"
+const instrumentationName = "github.com/overmindtech/cli"
 
 var tracer = otel.GetTracerProvider().Tracer(
 	instrumentationName,
@@ -70,7 +70,7 @@ func tracingResource() *resource.Resource {
 		resource.WithSchemaURL(semconv.SchemaURL),
 		// Add your own custom attributes to identify your application
 		resource.WithAttributes(
-			semconv.ServiceNameKey.String("ovm-cli"),
+			semconv.ServiceNameKey.String("overmind-cli"),
 			semconv.ServiceVersionKey.String("0.0.1"),
 		),
 	)


### PR DESCRIPTION
Renames the CLI to `overmind` and reorganises all the commands into subcommands based on the API

We also remove and consolidate a number of arguments