### PR TITLE
Use Device Authorization flow

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -370,20 +370,17 @@ func init() {
 		log.WithError(err).Fatal("could not bind api key to env")
 	}
 
+	// internal configs
 	rootCmd.PersistentFlags().String("cli-auth0-client-id", "QMfjMww3x4QTpeXiuRtMV3JIQkx6mZa4", "OAuth Client ID to use when connecting with auth0")
-	rootCmd.PersistentFlags().MarkHidden("cli-auth0-client-id")
 	rootCmd.PersistentFlags().String("cli-auth0-domain", "om-prod.eu.auth0.com", "Auth0 domain to connect to")
-	rootCmd.PersistentFlags().MarkHidden("cli-auth0-domain")
-
-	// tracing
 	rootCmd.PersistentFlags().String("honeycomb-api-key", "", "If specified, configures opentelemetry libraries to submit traces to honeycomb. This requires --otel to be set.")
-	// Mark this as hidden. This means that it will still be parsed of supplied,
+
+	// Mark these as hidden. This means that it will still be parsed of supplied,
 	// and we will still look for it in the environment, but it won't be shown
 	// in the help
-	err = rootCmd.PersistentFlags().MarkHidden("honeycomb-api-key")
-	if err != nil {
-		log.WithError(err).Fatal("could not mark `honeycomb-api-key` flag as hidden")
-	}
+	must(rootCmd.PersistentFlags().MarkHidden("cli-auth0-client-id"))
+	must(rootCmd.PersistentFlags().MarkHidden("cli-auth0-domain"))
+	must(rootCmd.PersistentFlags().MarkHidden("honeycomb-api-key"))
 
 	// Create groups
 	rootCmd.AddGroup(&cobra.Group{
@@ -438,4 +435,12 @@ func initConfig() {
 
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv() // read in environment variables that match
+}
+
+// must panics if the passed in error is not nil
+// use this for init-time error checking of viper/cobra stuff that sometimes errors if the flag does not exist
+func must(err error) {
+	if err != nil {
+		panic(fmt.Errorf("error initialising: %w", err))
+	}
 }


### PR DESCRIPTION
This replaces a bunch of cumbersome code with OAuth2 built-in functionality also ensuring that the actual device is authorized with no MitM attack.

This reverts the auth0 config flag removal to be able to test against non-prod environments.

Fixes https://github.com/overmindtech/cli/issues/174

Example session:
```
vscode ➜ /workspace/cli (main) $ rm /home/vscode/.overmind/token.json
vscode ➜ /workspace/cli (main) $ go run main.go request --query-type ec2-instance --query-method list --log debug
DEBU Error reading local token, ignoring: stat /home/vscode/.overmind/token.json: no such file or directory 
Go to https://om-dogfood.eu.auth0.com/activate?user_code=MJRB-ZNPH and verify this code: MJRB-ZNPH
INFO Authenticated successfully ✅                 
DEBU Saved token to /home/vscode/.overmind/token.json 
INFO received items                                error="<nil>"
INFO Query:
{
  "type": "ec2-instance",
  "method": 1,
  "recursionBehaviour": {},
  "scope": "*",
  "UUID": "1W9uBVpRR+O4JWLwnx4Pbw==",
  "deadline": {
    "seconds": 1708033535,
    "nanos": 454381490
  }
}  uuid=d56f6e05-5a51-47e3-b825-62f09f1e0f6f
DEBU query status update                           query=d56f6e05-5a51-47e3-b825-62f09f1e0f6f status=STARTED
INFO new item                                      item=944651592624.eu-west-2.ec2-instance.i-0967d3ae34899b1e8
INFO new item                                      item=944651592624.eu-west-2.ec2-instance.i-08b0f2a06b23905d5
INFO new item                                      item=944651592624.eu-west-2.ec2-instance.i-0da03dca5c6d870d9
DEBU query status update                           query=d56f6e05-5a51-47e3-b825-62f09f1e0f6f status=FINISHED
INFO all queries done                              edgesReceived=0 itemsReceived=3 queriesStarted=1
vscode ➜ /workspace/cli (main) $ go run main.go request --query-type ec2-instance --query-method list --log debug
DEBU Using local token from /home/vscode/.overmind/token.json 
INFO received items                                error="<nil>"
INFO Query:
{
  "type": "ec2-instance",
  "method": 1,
  "recursionBehaviour": {},
  "scope": "*",
  "UUID": "b0UwRriQRFuYieTNaKmocg==",
  "deadline": {
    "seconds": 1708033540,
    "nanos": 671043720
  }
}  uuid=6f453046-b890-445b-9889-e4cd68a9a872
DEBU query status update                           query=6f453046-b890-445b-9889-e4cd68a9a872 status=STARTED
INFO new item                                      item=944651592624.eu-west-2.ec2-instance.i-0967d3ae34899b1e8
INFO new item                                      item=944651592624.eu-west-2.ec2-instance.i-0da03dca5c6d870d9
INFO new item                                      item=944651592624.eu-west-2.ec2-instance.i-08b0f2a06b23905d5
DEBU query status update                           query=6f453046-b890-445b-9889-e4cd68a9a872 status=FINISHED
INFO all queries done                              edgesReceived=0 itemsReceived=3 queriesStarted=1
vscode ➜ /workspace/cli (main) $ 
```