### PR TITLE
Ensure reliable waiting for risks after a plan

### DIFF
--- a/cmd/tea_submitplan.go
+++ b/cmd/tea_submitplan.go
@@ -661,7 +661,8 @@ func (m submitPlanModel) submitPlanCmd() tea.Msg {
 			risks:          riskRes.Msg.GetChangeRiskMetadata().GetRisks(),
 		}}
 
-		if riskRes.Msg.GetChangeRiskMetadata().GetRiskCalculationStatus().GetStatus() == sdp.RiskCalculationStatus_STATUS_INPROGRESS {
+		status := riskRes.Msg.GetChangeRiskMetadata().GetRiskCalculationStatus().GetStatus()
+		if status == sdp.RiskCalculationStatus_STATUS_UNSPECIFIED || status == sdp.RiskCalculationStatus_STATUS_INPROGRESS {
 			time.Sleep(time.Second)
 			// retry
 		} else {

--- a/cmd/tea_submitplan.go
+++ b/cmd/tea_submitplan.go
@@ -150,9 +150,7 @@ func (m submitPlanModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.riskMilestones) > 0 {
 			m.riskTask.status = taskStatusRunning
 			cmds = append(cmds, m.riskTask.spinner.Tick)
-		} else if len(m.risks) > 0 {
-			m.riskTask.status = taskStatusDone
-		} else {
+
 			var allSkipped = true
 			for _, ms := range m.riskMilestoneTasks {
 				if ms.status != taskStatusSkipped {
@@ -163,6 +161,8 @@ func (m submitPlanModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if allSkipped {
 				m.riskTask.status = taskStatusSkipped
 			}
+		} else if len(m.risks) > 0 {
+			m.riskTask.status = taskStatusDone
 		}
 
 	case progressSnapshotMsg:


### PR DESCRIPTION
There was a short window where risk status would be reported as UNSPECIFIED when the calculation hadn't started yet on the first check. This lead to the CLI skipping waiting for risks, as `riskRes.Msg.GetChangeRiskMetadata().GetRiskCalculationStatus().GetStatus() == sdp.RiskCalculationStatus_STATUS_INPROGRESS` would return `false`.

Amongst a few cleanups this changes the logic so RiskCalculationStatus_STATUS_UNSPECIFIED also causes the CLI to wait for more results.