### PR TITLE
Fix "random" ANSI spew/UI hang

### DIFF
--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -9,7 +9,6 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/ansi"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
 type LogoPalette struct {
@@ -175,7 +174,7 @@ func MarkdownStyle() ansi.StyleConfig {
 	var labelMuted string
 	var labelTitle string
 
-	if termenv.HasDarkBackground() {
+	if lipgloss.HasDarkBackground() {
 		bgBase = ColorPalette.BgBase.Dark
 		bgMain = ColorPalette.BgMain.Dark
 		labelBase = ColorPalette.LabelBase.Dark

--- a/main.go
+++ b/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "github.com/overmindtech/cli/cmd"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/overmindtech/cli/cmd"
+)
 
 func main() {
+	// work around lipgloss/termenv integration bug.
+	// See https://github.com/charmbracelet/lipgloss/issues/73#issuecomment-1144921037
+	lipgloss.SetHasDarkBackground(termenv.HasDarkBackground())
+
 	cmd.Execute()
 }


### PR DESCRIPTION
It turns out that there is a lipgloss/termenv/bubbletea/reality incompatibility when querying the background color. By querying this once at the start before bubbletea takes control of the terminal, this can be avoided.

See https://github.com/charmbracelet/lipgloss/issues/73#issuecomment-1144921037 for details.

This fixes #347 