### PR TITLE
Count sensitive values in the plan for display

### DIFF
--- a/cmd/changes_submit_plan.go
+++ b/cmd/changes_submit_plan.go
@@ -396,7 +396,7 @@ func SubmitPlan(ctx context.Context, files []string, ready chan bool) int {
 
 	for _, f := range files {
 		lf["file"] = f
-		mappedItemDiffs, _, err := mappedItemDiffsFromPlanFile(ctx, f, lf)
+		_, mappedItemDiffs, _, err := mappedItemDiffsFromPlanFile(ctx, f, lf)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).WithFields(lf).Error("Error parsing terraform plan")
 			return 1

--- a/cmd/changes_submit_plan_test.go
+++ b/cmd/changes_submit_plan_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWithStateFile(t *testing.T) {
-	_,_, err := mappedItemDiffsFromPlanFile(context.Background(), "testdata/state.json", logrus.Fields{})
+	_, _, _, err := mappedItemDiffsFromPlanFile(context.Background(), "testdata/state.json", logrus.Fields{})
 
 	if err == nil {
 		t.Error("Expected error when running with state file, got none")

--- a/cmd/terraform_plan_test.go
+++ b/cmd/terraform_plan_test.go
@@ -9,10 +9,13 @@ import (
 )
 
 func TestMappedItemDiffsFromPlan(t *testing.T) {
-	mappedItemDiffs, _, err := mappedItemDiffsFromPlanFile(context.Background(), "testdata/plan.json", logrus.Fields{})
-
+	numSecrets, mappedItemDiffs, _, err := mappedItemDiffsFromPlanFile(context.Background(), "testdata/plan.json", logrus.Fields{})
 	if err != nil {
 		t.Error(err)
+	}
+
+	if numSecrets != 16 {
+		t.Errorf("Expected 16 secrets, got %v", numSecrets)
 	}
 
 	if len(mappedItemDiffs) != 5 {

--- a/cmd/testdata/plan.json
+++ b/cmd/testdata/plan.json
@@ -2388,6 +2388,11 @@
                         "cluster_name": "dogfood"
                     }
                 }
+            },
+            "test_secret": {
+                "sensitive": true,
+                "type": "string",
+                "value": "test_secret"
             }
         }
     },


### PR DESCRIPTION
This copies maskSensitiveData implementation to count sensitive values in the plan. This also counts sensitive inputs and outputs for modules.

Result:
![2024-06-06_14MS+0200_466x107](https://github.com/overmindtech/cli/assets/118179693/3dfcd09a-da35-43c5-ba0f-c3fe113a563a)
