### PR TITLE
Capture errors for quality management

### DIFF
--- a/cmd/changes_end_change.go
+++ b/cmd/changes_end_change.go
@@ -33,19 +33,34 @@ var endChangeCmd = &cobra.Command{
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		var exitcode int
+		// create a sub-scope to defer the span.End() to a point before shutting down the tracer
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		// Create a goroutine to watch for cancellation signals
-		go func() {
-			select {
-			case <-sigs:
-				cancel()
-			case <-ctx.Done():
+			ctx, span := tracing.Tracer().Start(ctx, "CLI EndChange", trace.WithAttributes(
+				attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
+			))
+			defer span.End()
+
+			// Create a goroutine to watch for cancellation signals
+			go func() {
+				select {
+				case <-sigs:
+					cancel()
+				case <-ctx.Done():
+				}
+			}()
+
+			exitcode = EndChange(ctx, nil)
+
+			span.SetAttributes(attribute.Int("ovm.cli.exitcode", exitcode))
+			if exitcode != 0 {
+				span.SetAttributes(attribute.Bool("ovm.cli.fatalError", true))
 			}
 		}()
 
-		exitcode := EndChange(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
@@ -57,11 +72,6 @@ func EndChange(ctx context.Context, ready chan bool) int {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
 		return 1
 	}
-
-	ctx, span := tracing.Tracer().Start(ctx, "CLI EndChange", trace.WithAttributes(
-		attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
-	))
-	defer span.End()
 
 	lf := log.Fields{
 		"app": viper.GetString("app"),

--- a/cmd/changes_get_change.go
+++ b/cmd/changes_get_change.go
@@ -45,19 +45,34 @@ var getChangeCmd = &cobra.Command{
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		var exitcode int
+		// create a sub-scope to defer the span.End() to a point before shutting down the tracer
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		// Create a goroutine to watch for cancellation signals
-		go func() {
-			select {
-			case <-sigs:
-				cancel()
-			case <-ctx.Done():
+			ctx, span := tracing.Tracer().Start(ctx, "CLI GetChange", trace.WithAttributes(
+				attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
+			))
+			defer span.End()
+
+			// Create a goroutine to watch for cancellation signals
+			go func() {
+				select {
+				case <-sigs:
+					cancel()
+				case <-ctx.Done():
+				}
+			}()
+
+			exitcode := GetChange(ctx, nil)
+
+			span.SetAttributes(attribute.Int("ovm.cli.exitcode", exitcode))
+			if exitcode != 0 {
+				span.SetAttributes(attribute.Bool("ovm.cli.fatalError", true))
 			}
 		}()
 
-		exitcode := GetChange(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
@@ -76,11 +91,6 @@ func GetChange(ctx context.Context, ready chan bool) int {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
 		return 1
 	}
-
-	ctx, span := tracing.Tracer().Start(ctx, "CLI GetChange", trace.WithAttributes(
-		attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
-	))
-	defer span.End()
 
 	lf := log.Fields{
 		"app": viper.GetString("app"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -446,10 +446,10 @@ func tracedSettings() map[string]any {
 		result["api-key"] = "[REDACTED]"
 	}
 	if viper.GetString("honeycomb-api-key") != "hcaik_01j03qe0exnn2jxpj2vxkqb7yrqtr083kyk9rxxt2wzjamz8be94znqmwa" {
-		result["honecomb-api-key"] = "[NON-DEFAULT]"
+		result["honeycomb-api-key"] = "[NON-DEFAULT]"
 	}
 	if viper.GetString("sentry-dsn") != "https://276b6d99c77358d9bf85aafbff81b515@o4504565700886528.ingest.us.sentry.io/4507413529690112" {
-		result["honecomb-api-key"] = "[NON-DEFAULT]"
+		result["sentry-dsn"] = "[NON-DEFAULT]"
 	}
 	result["ovm-test-fake"] = viper.GetString("ovm-test-fake")
 	result["run-mode"] = viper.GetString("run-mode")

--- a/tracing/main.go
+++ b/tracing/main.go
@@ -45,10 +45,10 @@ func tracingResource() *resource.Resource {
 
 	res, err := resource.New(context.Background(),
 		resource.WithDetectors(detectors...),
-		// Keep the default detectors
+		// replace the default detectors
 		resource.WithHost(),
 		resource.WithOS(),
-		resource.WithProcess(),
+		// resource.WithProcess(), // don't capture potentially sensitive customer info
 		resource.WithContainer(),
 		resource.WithTelemetrySDK(),
 		resource.WithSchemaURL(semconv.SchemaURL),


### PR DESCRIPTION
This also removes the CLI and other process metadata from the captured traces to avoid recording sensitive information, like tfvars.