### PR TITLE
Refactor cli command initialisation and error reporting

### DIFF
--- a/cmd/bookmarks_get_affected_bookmarks.go
+++ b/cmd/bookmarks_get_affected_bookmarks.go
@@ -1,68 +1,30 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // getAffectedBookmarksCmd represents the get-affected-bookmarks command
 var getAffectedBookmarksCmd = &cobra.Command{
-	Use:   "get-affected-bookmarks --snapshot-uuid ID --bookmark-uuids ID,ID,ID",
-	Short: "Calculates the bookmarks that would be overlapping with a snapshot.",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		// Bind these to viper
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.WithError(err).Fatal("could not bind `get-affected-bookmarks` flags")
-		}
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		// Create a goroutine to watch for cancellation signals
-		go func() {
-			select {
-			case <-sigs:
-				cancel()
-			case <-ctx.Done():
-			}
-		}()
-
-		exitcode := GetAffectedBookmarks(ctx, nil)
-		tracing.ShutdownTracer()
-		os.Exit(exitcode)
-	},
+	Use:    "get-affected-bookmarks --snapshot-uuid ID --bookmark-uuids ID,ID,ID",
+	Short:  "Calculates the bookmarks that would be overlapping with a snapshot.",
+	PreRun: PreRunSetup,
+	RunE:   GetAffectedBookmarks,
 }
 
-func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
-	timeout, err := time.ParseDuration(viper.GetString("timeout"))
-	if err != nil {
-		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
-		return 1
-	}
+func GetAffectedBookmarks(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 
 	snapshotUuid, err := uuid.Parse(viper.GetString("snapshot-uuid"))
 	if err != nil {
-		log.Errorf("invalid --snapshot-uuid value '%v', error: %v", viper.GetString("uuid"), err)
-		return 1
+		return flagError{usage: fmt.Sprintf("invalid --snapshot-uuid value '%v': %v\n\n%v", viper.GetString("snapshot-uuid"), err, cmd.UsageString())}
 	}
 
 	uuidStrings := viper.GetStringSlice("bookmark-uuids")
@@ -70,36 +32,15 @@ func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
 	for _, s := range uuidStrings {
 		bookmarkUuid, err := uuid.Parse(s)
 		if err != nil {
-			log.Errorf("invalid --bookmark-uuids value '%v', error: %v", bookmarkUuid, err)
-			return 1
+			return flagError{usage: fmt.Sprintf("invalid --bookmark-uuids value '%v': %v\n\n%v", bookmarkUuid, err, cmd.UsageString())}
 		}
 		bookmarkUuids = append(bookmarkUuids, bookmarkUuid[:])
 	}
 
-	ctx, span := tracing.Tracer().Start(ctx, "CLI GetAffectedBookmarks", trace.WithAttributes(
-		attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
-	))
-	defer span.End()
-
-	lf := log.Fields{
-		"app": viper.GetString("app"),
-	}
-
-	oi, err := NewOvermindInstance(ctx, viper.GetString("app"))
+	ctx, oi, _, err := login(ctx, cmd, []string{"changes:read"})
 	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to get instance data from app")
-		return 1
+		return err
 	}
-
-	ctx, _, err = ensureToken(ctx, oi, []string{"changes:read"})
-	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to authenticate")
-		return 1
-	}
-
-	// apply a timeout to the main body of processing
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	client := AuthenticatedBookmarkClient(ctx, oi)
 	response, err := client.GetAffectedBookmarks(ctx, &connect.Request[sdp.GetAffectedBookmarksRequest]{
@@ -109,8 +50,10 @@ func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
 		},
 	})
 	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to get affected bookmarks")
-		return 1
+		return loggedError{
+			err:     err,
+			message: "Failed to get affected bookmarks.",
+		}
 	}
 	for _, u := range response.Msg.GetBookmarkUUIDs() {
 		bookmarkUuid := uuid.UUID(u)
@@ -118,7 +61,7 @@ func GetAffectedBookmarks(ctx context.Context, ready chan bool) int {
 			"uuid": bookmarkUuid,
 		}).Info("found affected bookmark")
 	}
-	return 0
+	return nil
 }
 
 func init() {

--- a/cmd/bookmarks_get_bookmark.go
+++ b/cmd/bookmarks_get_bookmark.go
@@ -1,95 +1,39 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
-	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // getBookmarkCmd represents the get-bookmark command
 var getBookmarkCmd = &cobra.Command{
-	Use:   "get-bookmark --uuid ID",
-	Short: "Displays the contents of a bookmark.",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		// Bind these to viper
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.WithError(err).Fatal("could not bind `get-bookmark` flags")
-		}
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		// Create a goroutine to watch for cancellation signals
-		go func() {
-			select {
-			case <-sigs:
-				cancel()
-			case <-ctx.Done():
-			}
-		}()
-
-		exitcode := GetBookmark(ctx, nil)
-		tracing.ShutdownTracer()
-		os.Exit(exitcode)
-	},
+	Use:    "get-bookmark --uuid ID",
+	Short:  "Displays the contents of a bookmark.",
+	PreRun: PreRunSetup,
+	RunE:   GetBookmark,
 }
 
-func GetBookmark(ctx context.Context, ready chan bool) int {
-	timeout, err := time.ParseDuration(viper.GetString("timeout"))
-	if err != nil {
-		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
-		return 1
-	}
+func GetBookmark(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 
 	bookmarkUuid, err := uuid.Parse(viper.GetString("uuid"))
 	if err != nil {
-		log.Errorf("invalid --uuid value '%v', error: %v", viper.GetString("uuid"), err)
-		return 1
+		return flagError{
+			usage: fmt.Sprintf("invalid --uuid value '%v' (%v)\n\n%v", viper.GetString("uuid"), err, cmd.UsageString()),
+		}
 	}
 
-	ctx, span := tracing.Tracer().Start(ctx, "CLI GetBookmark", trace.WithAttributes(
-		attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
-	))
-	defer span.End()
-
-	lf := log.Fields{
-		"app": viper.GetString("app"),
-	}
-
-	oi, err := NewOvermindInstance(ctx, viper.GetString("app"))
+	ctx, oi, _, err := login(ctx, cmd, []string{"changes:read"})
 	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to get instance data from app")
-		return 1
+		return err
 	}
-
-	ctx, _, err = ensureToken(ctx, oi, []string{"changes:read"})
-	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to authenticate")
-		return 1
-	}
-
-	// apply a timeout to the main body of processing
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	client := AuthenticatedBookmarkClient(ctx, oi)
 	response, err := client.GetBookmark(ctx, &connect.Request[sdp.GetBookmarkRequest]{
@@ -98,8 +42,10 @@ func GetBookmark(ctx context.Context, ready chan bool) int {
 		},
 	})
 	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to get bookmark")
-		return 1
+		return loggedError{
+			err:     err,
+			message: "failed to get bookmark",
+		}
 	}
 	log.WithContext(ctx).WithFields(log.Fields{
 		"bookmark-uuid":        uuid.UUID(response.Msg.GetBookmark().GetMetadata().GetUUID()),
@@ -115,7 +61,7 @@ func GetBookmark(ctx context.Context, ready chan bool) int {
 		fmt.Println(string(b))
 	}
 
-	return 0
+	return nil
 }
 
 func init() {

--- a/cmd/changes_start_change.go
+++ b/cmd/changes_start_change.go
@@ -1,105 +1,44 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
 	"connectrpc.com/connect"
-	"github.com/overmindtech/cli/tracing"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // startChangeCmd represents the start-change command
 var startChangeCmd = &cobra.Command{
-	Use:   "start-change --uuid ID",
-	Short: "Starts the specified change. Call this just before you're about to start the change. This will store a snapshot of the current system state for later reference.",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		// Bind these to viper
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.WithError(err).Fatal("could not bind `start-change` flags")
-		}
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-		var exitcode int
-		// create a sub-scope to defer the span.End() to a point before shutting down the tracer
-		func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			ctx, span := tracing.Tracer().Start(ctx, "CLI StartChange", trace.WithAttributes(
-				attribute.String("ovm.config", fmt.Sprintf("%v", tracedSettings())),
-			))
-			defer span.End()
-
-			// Create a goroutine to watch for cancellation signals
-			go func() {
-				select {
-				case <-sigs:
-					cancel()
-				case <-ctx.Done():
-				}
-			}()
-
-			exitcode = StartChange(ctx, nil)
-
-			span.SetAttributes(attribute.Int("ovm.cli.exitcode", exitcode))
-			if exitcode != 0 {
-				span.SetAttributes(attribute.Bool("ovm.cli.fatalError", true))
-			}
-		}()
-
-		tracing.ShutdownTracer()
-		os.Exit(exitcode)
-	},
+	Use:    "start-change --uuid ID",
+	Short:  "Starts the specified change. Call this just before you're about to start the change. This will store a snapshot of the current system state for later reference.",
+	PreRun: PreRunSetup,
+	RunE:   StartChange,
 }
 
-func StartChange(ctx context.Context, ready chan bool) int {
-	timeout, err := time.ParseDuration(viper.GetString("timeout"))
+func StartChange(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	ctx, oi, _, err := login(ctx, cmd, []string{"changes:write"})
 	if err != nil {
-		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
-		return 1
+		return err
 	}
-
-	lf := log.Fields{
-		"app": viper.GetString("app"),
-	}
-
-	oi, err := NewOvermindInstance(ctx, viper.GetString("app"))
-	if err != nil {
-		log.WithContext(ctx).WithError(err).WithFields(lf).Error("failed to get instance data from app")
-		return 1
-	}
-
-	ctx, _, err = ensureToken(ctx, oi, []string{"changes:write"})
-	if err != nil {
-		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to authenticate")
-		return 1
-	}
-
-	// apply a timeout to the main body of processing
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	changeUuid, err := getChangeUuid(ctx, oi, sdp.ChangeStatus_CHANGE_STATUS_DEFINING, viper.GetString("ticket-link"), true)
 	if err != nil {
-		log.WithError(err).WithFields(lf).Error("failed to identify change")
-		return 1
+		return loggedError{
+			err: err,
+			fields: log.Fields{
+				"ticket-link": viper.GetString("ticket-link"),
+			},
+			message: "failed to identify change",
+		}
 	}
 
-	lf["uuid"] = changeUuid.String()
+	lf := log.Fields{
+		"uuid":        changeUuid.String(),
+		"ticket-link": viper.GetString("ticket-link"),
+	}
 
 	// snapClient := AuthenticatedSnapshotsClient(ctx)
 	client := AuthenticatedChangesClient(ctx, oi)
@@ -109,8 +48,11 @@ func StartChange(ctx context.Context, ready chan bool) int {
 		},
 	})
 	if err != nil {
-		log.WithContext(ctx).WithFields(lf).WithError(err).Error("failed to start change")
-		return 1
+		return loggedError{
+			err:     err,
+			fields:  lf,
+			message: "failed to start change",
+		}
 	}
 	log.WithContext(ctx).WithFields(lf).Info("processing")
 	for stream.Receive() {
@@ -122,12 +64,15 @@ func StartChange(ctx context.Context, ready chan bool) int {
 		}).Info("progress")
 	}
 	if stream.Err() != nil {
-		log.WithContext(ctx).WithFields(lf).WithError(stream.Err()).Error("failed to process start change")
-		return 1
+		return loggedError{
+			err:     err,
+			fields:  lf,
+			message: "failed to process start change",
+		}
 	}
 
 	log.WithContext(ctx).WithFields(lf).Info("started change")
-	return 0
+	return nil
 }
 
 func init() {

--- a/cmd/tea.go
+++ b/cmd/tea.go
@@ -92,9 +92,11 @@ func CmdWrapper(action string, requiredScopes []string, commandModel func(args [
 
 		// wrap the rest of the function in a closure to allow for cleaner error handling and deferring.
 		err := func() error {
+			ctx := cmd.Context()
+
 			timeout, err := time.ParseDuration(viper.GetString("timeout"))
 			if err != nil {
-				return fmt.Errorf("invalid --timeout value '%v', error: %w", viper.GetString("timeout"), err)
+				return flagError{usage: fmt.Sprintf("invalid --timeout value '%v'\n\n%v", viper.GetString("timeout"), cmd.UsageString())}
 			}
 
 			app, err := viperGetApp(ctx)

--- a/cmd/terraform_apply.go
+++ b/cmd/terraform_apply.go
@@ -23,13 +23,7 @@ import (
 var terraformApplyCmd = &cobra.Command{
 	Use:   "apply [overmind options...] -- [terraform options...]",
 	Short: "Runs `terraform apply` between two full system configuration snapshots for tracking. This will be automatically connected with the Change created by the `plan` command.",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		// Bind these to viper
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.WithError(err).Fatal("could not bind `terraform apply` flags")
-		}
-	},
+	PreRun: PreRunSetup,
 	Run: CmdWrapper("apply", []string{"explore:read", "changes:write", "config:write", "request:receive"}, NewTfApplyModel),
 }
 

--- a/cmd/terraform_plan.go
+++ b/cmd/terraform_plan.go
@@ -15,22 +15,15 @@ import (
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // terraformPlanCmd represents the `terraform plan` command
 var terraformPlanCmd = &cobra.Command{
-	Use:   "plan [overmind options...] -- [terraform options...]",
-	Short: "Runs `terraform plan` and sends the results to Overmind to calculate a blast radius and risks.",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		// Bind these to viper
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.WithError(err).Fatal("could not bind `terraform plan` flags")
-		}
-	},
-	Run: CmdWrapper("plan", []string{"explore:read", "changes:write", "config:write", "request:receive"}, NewTfPlanModel),
+	Use:    "plan [overmind options...] -- [terraform options...]",
+	Short:  "Runs `terraform plan` and sends the results to Overmind to calculate a blast radius and risks.",
+	PreRun: PreRunSetup,
+	Run:    CmdWrapper("plan", []string{"explore:read", "changes:write", "config:write", "request:receive"}, NewTfPlanModel),
 }
 
 type tfPlanModel struct {


### PR DESCRIPTION
This unifies all commands to use shared setup/login/error reporting facilities and provide usage info when flag validation fails.

Examples for flagErrors:

```
vscode ➜ /workspace/cli (dev) $ time go run main.go request load --snapshot-uuid foo
Failed to parse UUID 'foo': invalid UUID length: 3

Usage:
  overmind request load [flags]

Flags:
      --app string             The overmind instance to connect to. (default "https://app.overmind.tech")
[...]

vscode ➜ /workspace/cli (dev) $ time go run main.go request load --snapshot foo
unknown flag: --snapshot

Usage:
  overmind request load [flags]

Flags:
      --app string             The overmind instance to connect to. (default "https://app.overmind.tech")
[...]
```

Example for loggedError:

```
vscode ➜ /workspace/cli (dev) $ time go run main.go request query --query foo
ERRO Failed to connect to overmind API             error="failed to WebSocket dial: expected handshake response status code 101 but got 200" gateway-url="https://api.df.overmind-demo.com/api/gateway"
```