### PR TITLE
Capture error message for tracing on the span itself

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -218,7 +218,10 @@ func Execute() {
 			// if printing the error was not requested by the appropriate
 			// wrapper, only record the data to honeycomb and sentry, the
 			// command already has handled logging
-			cmdSpan.SetAttributes(attribute.Bool("ovm.cli.fatalError", true))
+			cmdSpan.SetAttributes(
+				attribute.Bool("ovm.cli.fatalError", true),
+				attribute.String("ovm.cli.fatalError.msg", err.Error()),
+			)
 			cmdSpan.RecordError(err)
 			sentry.CaptureException(err)
 		}

--- a/cmd/tea_terraform.go
+++ b/cmd/tea_terraform.go
@@ -145,6 +145,7 @@ func (m *cmdModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		span.SetAttributes(
 			attribute.Bool("ovm.cli.fatalError", true),
 			attribute.Int("ovm.cli.fatalError.id", msg.id),
+			attribute.String("ovm.cli.fatalError.msg", msg.err.Error()),
 		)
 		sentry.CaptureException(msg.err)
 


### PR DESCRIPTION
`span.RecordError` adds an `exception` span event, which is nive to have to see the timing, but awful for aggregation in honeycomb. This also adds the most relevant data to the span for easier querying.