### PR TITLE
Fix typo breaking `terraform apply` start change snapshots

### DIFF
--- a/cmd/terraform_apply.go
+++ b/cmd/terraform_apply.go
@@ -488,7 +488,7 @@ func (m tfApplyModel) startStartChangeCmd() tea.Cmd {
 			return nil
 		}
 
-		m.endingChange <- m.startingChangeSnapshot.FinishMsg()
+		m.startingChange <- m.startingChangeSnapshot.FinishMsg()
 		return nil
 	}
 }


### PR DESCRIPTION
This was introduced in https://github.com/overmindtech/cli/pull/435 which is not part of any release