### PR TITLE
Add a link to discord on errors

### DIFF
--- a/cmd/tea_terraform.go
+++ b/cmd/tea_terraform.go
@@ -291,10 +291,10 @@ func (m cmdModel) View() string {
 
 	bits = append(bits, m.cmd.View())
 	if m.fatalError != "" {
-		md := markdownToString(m.width, fmt.Sprintf("> Fatal Error: %v\n", m.fatalError))
-		md, _ = strings.CutPrefix(md, "\n")
-		md, _ = strings.CutSuffix(md, "\n")
-		bits = append(bits, md)
+		md := markdownToString(m.width, fmt.Sprintf("> Fatal Error: %v", m.fatalError))
+		bits = append(bits, strings.Trim(md, "\n"))
+		md = markdownToString(m.width, "> Get help in our [Discord](https://discord.com/invite/5UKsqAkPWG)")
+		bits = append(bits, strings.Trim(md, "\n"))
 	}
 	bits = slices.DeleteFunc(bits, func(s string) bool {
 		return s == "" || s == "\n"


### PR DESCRIPTION
Fixes #469 

![2024-07-22_10MS+0200_926x137](https://github.com/user-attachments/assets/ffc1328b-36cd-4a10-a0b0-4c9819dfb218)

I spent a few minutes trying to remove the empty line, but the markdown renderer proved to be intransigent.