### PR TITLE
Capture a cleaner service version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-//go:generate sh -c "echo -n $(git describe --tags --always) > commit.txt"
+//go:generate sh -c "echo -n $(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD) > commit.txt"
 //go:embed commit.txt
 var cliVersion string
 

--- a/tracing/main.go
+++ b/tracing/main.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-//go:generate sh -c "echo -n $(git describe --tags --long) > commit.txt"
+//go:generate sh -c "echo -n $(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD) > commit.txt"
 //go:embed commit.txt
 var instrumentationVersion string
 


### PR DESCRIPTION
This means that we get either the SHA of of the commit, or the tag, rather than the somewhat confusing `heads/main-0-gd4c5dc9` that we get at the moment. This is especially confusing since the SHA is the 7 digits, not 8 (i.e. `d4c5dc9` not `gd4c5dc9`)