### PR TITLE
Improve feedback when failing to parse terraform providers for AWS

### DIFF
--- a/cmd/explore.go
+++ b/cmd/explore.go
@@ -108,6 +108,7 @@ func StartLocalSources(ctx context.Context, oi sdp.OvermindInstance, token *oaut
 				// skip providers that had errors. This allows us to use
 				// providers we _could_ detect, while still failing if there is
 				// a true syntax error and no providers are available at all.
+				statusArea.Println(fmt.Sprintf("Skipping AWS provider in %s with %s.", p.FilePath, p.Error.Error()))
 				continue
 			}
 			c, err := tfutils.ConfigFromProvider(ctx, *p.Provider)


### PR DESCRIPTION
This PR adds printing the errors from parsing terraform providers to allow customers to better understand what is going wrong.

Fixes #673 

On manual testing, I could verify that access keys do work, but reproducing more of the customer's issue revealed some missing diagnostic output that would have indicated the underlying issue.

Example output:

```
vscode ➜ /workspace/deploy (dev) $ overmind terraform apply
DEBU sentry configured                            
 ✔︎  Connected to Overmind
 ✔︎  Stdlib source engine started
 ✗  Failed to initialize AWS source engine
Skipping AWS provider in main.tf with error decoding terraform file: (main.tf) main.tf:2,15-22: Unsupported attribute; This object does not
have an attribute named "REGION"., and 1 other diagnostic(s).
Error: error starting sources: failed to initialize AWS source engine: No configs specified
vscode ➜ /workspace/deploy (dev) $
```