### PR TITLE
Only print progress messages every two seconds

### DIFF
--- a/cmd/changes_end_change.go
+++ b/cmd/changes_end_change.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"connectrpc.com/connect"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
@@ -48,13 +50,18 @@ func EndChange(cmd *cobra.Command, args []string) error {
 		}
 	}
 	log.WithContext(ctx).WithFields(lf).Info("processing")
+	lastLog := time.Now().Add(-1 * time.Minute)
 	for stream.Receive() {
 		msg := stream.Msg()
-		log.WithContext(ctx).WithFields(lf).WithFields(log.Fields{
-			"state": msg.GetState(),
-			"items": msg.GetNumItems(),
-			"edges": msg.GetNumEdges(),
-		}).Info("progress")
+		// print progress every 2 seconds
+		if time.Now().After(lastLog.Add(2 * time.Second)) {
+			log.WithContext(ctx).WithFields(lf).WithFields(log.Fields{
+				"state": msg.GetState(),
+				"items": msg.GetNumItems(),
+				"edges": msg.GetNumEdges(),
+			}).Info("progress")
+			lastLog = time.Now()
+		}
 	}
 	if stream.Err() != nil {
 		return loggedError{

--- a/cmd/terraform_apply.go
+++ b/cmd/terraform_apply.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -153,13 +154,18 @@ func TerraformApplyImpl(ctx context.Context, cmd *cobra.Command, oi sdp.Overmind
 		}
 
 		var startMsg *sdp.StartChangeResponse
+		lastLog := time.Now().Add(-1 * time.Minute)
 		for startStream.Receive() {
 			startMsg = startStream.Msg()
-			log.WithFields(log.Fields{
-				"state": startMsg.GetState(),
-				"items": startMsg.GetNumItems(),
-				"edges": startMsg.GetNumEdges(),
-			}).Trace("progress")
+			// print progress every 2 seconds
+			if time.Now().After(lastLog.Add(2 * time.Second)) {
+				log.WithFields(log.Fields{
+					"state": startMsg.GetState(),
+					"items": startMsg.GetNumItems(),
+					"edges": startMsg.GetNumEdges(),
+				}).Trace("progress")
+				lastLog = time.Now()
+			}
 			stateLabel := "unknown"
 			switch startMsg.GetState() {
 			case sdp.StartChangeResponse_STATE_UNSPECIFIED:
@@ -212,13 +218,18 @@ func TerraformApplyImpl(ctx context.Context, cmd *cobra.Command, oi sdp.Overmind
 	}
 
 	var endMsg *sdp.EndChangeResponse
+	lastLog := time.Now().Add(-1 * time.Minute)
 	for endStream.Receive() {
 		endMsg = endStream.Msg()
-		log.WithFields(log.Fields{
-			"state": endMsg.GetState(),
-			"items": endMsg.GetNumItems(),
-			"edges": endMsg.GetNumEdges(),
-		}).Trace("progress")
+		// print progress every 2 seconds
+		if time.Now().After(lastLog.Add(2 * time.Second)) {
+			log.WithFields(log.Fields{
+				"state": endMsg.GetState(),
+				"items": endMsg.GetNumItems(),
+				"edges": endMsg.GetNumEdges(),
+			}).Trace("progress")
+			lastLog = time.Now()
+		}
 		stateLabel := "unknown"
 		switch endMsg.GetState() {
 		case sdp.EndChangeResponse_STATE_UNSPECIFIED:


### PR DESCRIPTION
This should avoid the excessively long logs in CI when starting or ending changes.