### PR TITLE
fix: correct misleading comments and use structured logging for errors

### DIFF
--- a/cmd/bookmarks_create_bookmark.go
+++ b/cmd/bookmarks_create_bookmark.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// createBookmarkCmd represents the get-bookmark command
+// createBookmarkCmd represents the create-bookmark command
 var createBookmarkCmd = &cobra.Command{
 	Use:    "create-bookmark [--file FILE]",
 	Short:  "Creates a bookmark from JSON.",
@@ -71,7 +71,7 @@ func CreateBookmark(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return loggedError{
 			err:     err,
-			message: "failed to get bookmark",
+			message: "failed to create bookmark",
 		}
 	}
 	log.WithContext(ctx).WithFields(log.Fields{
@@ -88,7 +88,7 @@ func CreateBookmark(cmd *cobra.Command, args []string) error {
 
 	b, err := json.MarshalIndent(response.Msg.GetBookmark().GetProperties(), "", "  ")
 	if err != nil {
-		log.Infof("Error rendering bookmark: %v", err)
+		log.WithError(err).Warn("failed to render bookmark")
 	} else {
 		fmt.Println(string(b))
 	}

--- a/cmd/bookmarks_get_bookmark.go
+++ b/cmd/bookmarks_get_bookmark.go
@@ -56,7 +56,7 @@ func GetBookmark(cmd *cobra.Command, args []string) error {
 
 	b, err := json.MarshalIndent(response.Msg.GetBookmark().ToMap(), "", "  ")
 	if err != nil {
-		log.Infof("Error rendering bookmark: %v", err)
+		log.WithError(err).Warn("failed to render bookmark")
 	} else {
 		fmt.Println(string(b))
 	}

--- a/cmd/changes_list_changes.go
+++ b/cmd/changes_list_changes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// listChangesCmd represents the get-change command
+// listChangesCmd represents the list-changes command
 var listChangesCmd = &cobra.Command{
 	Use:    "list-changes --dir ./output",
 	Short:  "Displays the contents of a change.",

--- a/cmd/changes_submit_signal.go
+++ b/cmd/changes_submit_signal.go
@@ -78,7 +78,7 @@ func SubmitSignal(cmd *cobra.Command, args []string) error {
 	b, err := json.MarshalIndent(returnedSignal.Msg, "", "  ")
 	if err != nil {
 		fmt.Printf("Successfully created signal for change %s\n", changeUUID.String())
-		log.Infof("Error rendering Signal: %v", err)
+		log.WithError(err).Warn("failed to render signal")
 	} else {
 		fmt.Printf("Successfully created signal for change %s\n", changeUUID.String())
 		fmt.Println(string(b))

--- a/cmd/invites_crud.go
+++ b/cmd/invites_crud.go
@@ -53,7 +53,6 @@ func InvitesRevoke(cmd *cobra.Command, args []string) error {
 
 	client := AuthenticatedInviteClient(ctx, oi)
 
-	// Create the invite
 	_, err = client.RevokeInvite(ctx, &connect.Request[sdp.RevokeInviteRequest]{
 		Msg: &sdp.RevokeInviteRequest{
 			Email: email,

--- a/cmd/snapshots_get_snapshot.go
+++ b/cmd/snapshots_get_snapshot.go
@@ -64,7 +64,7 @@ func GetSnapshot(cmd *cobra.Command, args []string) error {
 
 	b, err := json.MarshalIndent(response.Msg.GetSnapshot().ToMap(), "", "  ")
 	if err != nil {
-		log.Infof("Error rendering snapshot: %v", err)
+		log.WithError(err).Warn("failed to render snapshot")
 	} else {
 		fmt.Println(string(b))
 	}


### PR DESCRIPTION
## Summary

- Fix misleading comments that referenced wrong command names
- Fix an incorrect error message in CreateBookmark ("failed to get" → "failed to create")
- Migrate 4 instances of `log.Infof("Error ...")` to structured `log.WithError(err).Warn(...)` for consistency with the rest of the codebase

## Changes

### Misleading comments
- `cmd/bookmarks_create_bookmark.go`: comment said "get-bookmark" but the command creates bookmarks
- `cmd/changes_list_changes.go`: comment said "get-change" but the command lists changes
- `cmd/invites_crud.go`: comment in `InvitesRevoke` said "Create the invite"

### Incorrect error message
- `cmd/bookmarks_create_bookmark.go`: RPC error message said "failed to get bookmark" when it should say "failed to create bookmark"

### Structured logging
- Replaced `log.Infof("Error ...: %v", err)` with `log.WithError(err).Warn(...)` in 4 files for consistency

## Linear

Resolves [ENG-3664](https://linear.app/overmind/issue/ENG-3664)

Made with [Cursor](https://cursor.com)